### PR TITLE
Replaced el8 with ol8

### DIFF
--- a/docker-envs/docker-compose.yml
+++ b/docker-envs/docker-compose.yml
@@ -19,12 +19,12 @@ services:
       context: ../
       dockerfile: ./docker-envs/Dockerfile-el7
     volumes: *default-volumes
-  el8:
-    image: ghcr.io/perfsonar/unibuild/el8:latest
+  ol8:
+    image: ghcr.io/perfsonar/unibuild/ol8:latest
     platform: linux/amd64
     build:
       context: ../
-      dockerfile: ./docker-envs/Dockerfile-el8
+      dockerfile: ./docker-envs/Dockerfile-ol8
     volumes: *default-volumes
   el9:
     image: ghcr.io/perfsonar/unibuild/el9:latest


### PR DESCRIPTION
Replace refs to el8 with ol8 in compose-file since only Dockerfile-ol8 i now supported.