### PR TITLE
Move arm* builds to native architecture runners.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,22 +24,21 @@ env:
 
 jobs:
   build:
-    # Iterates through each OS using a matrix strategy
-    # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs
     strategy:
       fail-fast: true
       matrix:
         os: [ 'ol8', 'el9', 'el10', 'u20', 'u22', 'u24', 'u26' ]
-        arch: ['amd64', 'arm64']
+        arch: [ 'amd64', 'arm64' ]
         include:
-          # Map 'amd64' builds to native Intel/AMD runners
+          # Intel Runner: Compiles native x86 AND safely triggers emulated tasks for supported OS versions
           - arch: amd64
             runner: ubuntu-latest
-            platform: linux/amd64
-          # Map 'arm64' builds to native ARM runners (Fixes QEMU Segfault!)
+            # The trick: Conditionally append arm/v7 and ppc64le ONLY if it's Ubuntu ('u')
+            platforms: >-
+              linux/amd64
           - arch: arm64
             runner: ubuntu-24.04-arm64
-            platform: linux/arm64
+            platforms: linux/arm64
 
     runs-on: ${{ matrix.runner }}
     permissions:
@@ -96,33 +95,20 @@ jobs:
       #
       # Platform Builds
       #
-
-      # amd64 and arm64 -- OL, EL, Debian and Ubuntu
-
-      - name: Build and push amd64 and arm64
+      - name: Build and push images
         id: build-and-push
-        # No condition here; build everything on these platforms.
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./docker-envs/Dockerfile-${{ matrix.os }}
-          platforms: ${{ matrix.platform }}
+          # Dynamically builds whatever platforms are defined for this specific runner/OS match
+          platforms: >-
+            ${{ matrix.platform }}${{ 
+              (matrix.arch == 'amd64' && startsWith(matrix.os, 'u')) 
+              && ',linux/arm/v7,linux/ppc64le' 
+              || '' 
+            }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      # armv7 and ppc64le - Debian and Ubuntu
-
-      - name: Build and push armv7 and ppc64le
-        id: build-and-push-multiarch
-        if: matrix.arch == 'amd64' && (startsWith(matrix.os, 'u') || startsWith(matrix.os, 'd'))
-        # if: ${{ startsWith(matrix.os, 'd') || startsWith(matrix.os, 'u') }}
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./docker-envs/Dockerfile-${{ matrix.os }}
-          # These platforms fail: linux/arm/v7, linux/ppc64le
-          platforms: linux/arm/v7, linux/ppc64le
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -115,6 +115,7 @@ jobs:
 
       - name: Build and push armv7 and ppc64le
         id: build-and-push-multiarch
+        if: matrix.arch == 'amd64' && (startsWith(matrix.os, 'u') || startsWith(matrix.os, 'd'))
         # if: ${{ startsWith(matrix.os, 'd') || startsWith(matrix.os, 'u') }}
         uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -48,6 +48,16 @@ jobs:
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          # Automatically preserves your default execution privileges while passing parameters
+          buildkitd-flags: --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host
+          # Tells QEMU/BuildKit to cleanly map 64-bit kernel filesystem structures down to a 32-bit layout
+          buildkitd-config-inline: |
+            [worker.oci]
+              gcounter = false
+            [worker.containerd]
+              prefer32 = true
+ 
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,8 +30,18 @@ jobs:
       fail-fast: true
       matrix:
         os: [ 'ol8', 'el9', 'el10', 'u20', 'u22', 'u24', 'u26' ]
+        arch: ['amd64', 'arm64']
+        include:
+          # Map 'amd64' builds to native Intel/AMD runners
+          - arch: amd64
+            runner: ubuntu-latest
+            platform: linux/amd64
+          # Map 'arm64' builds to native ARM runners (Fixes QEMU Segfault!)
+          - arch: arm64
+            runner: ubuntu-24.04-arm64
+            platform: linux/arm64
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -44,6 +54,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up QEMU
+		if: matrix.arch == 'amd64'
         uses: docker/setup-qemu-action@v4
 
       - name: Setup Docker buildx
@@ -53,8 +64,6 @@ jobs:
           buildkitd-flags: --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host
           # Tells QEMU/BuildKit to cleanly map 64-bit kernel filesystem structures down to a 32-bit layout
           buildkitd-config-inline: |
-            [worker.oci]
-              gcounter = false
             [worker.containerd]
               prefer32 = true
  
@@ -97,7 +106,7 @@ jobs:
         with:
           context: .
           file: ./docker-envs/Dockerfile-${{ matrix.os }}
-          platforms: linux/amd64, linux/arm64
+          platforms: ${{ matrix.platform }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -106,7 +115,7 @@ jobs:
 
       - name: Build and push armv7 and ppc64le
         id: build-and-push-multiarch
-        if: ${{ startsWith(matrix.os, 'd') || startsWith(matrix.os, 'u') }}
+        # if: ${{ startsWith(matrix.os, 'd') || startsWith(matrix.os, 'u') }}
         uses: docker/build-push-action@v7
         with:
           context: .

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up QEMU
-		if: matrix.arch == 'amd64'
+        if: matrix.arch == 'amd64'
         uses: docker/setup-qemu-action@v4
 
       - name: Setup Docker buildx

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -103,9 +103,13 @@ jobs:
           file: ./docker-envs/Dockerfile-${{ matrix.os }}
           # Dynamically builds whatever platforms are defined for this specific runner/OS match
           platforms: >-
-            ${{ matrix.platform }}${{ 
-              (matrix.arch == 'amd64' && startsWith(matrix.os, 'u')) 
-              && ',linux/arm/v7,linux/ppc64le' 
+            ${{ matrix.arch == 'arm64' && 'linux/arm64' || '' }}${{
+              (matrix.arch == 'amd64' && (matrix.os == 'u20' || matrix.os == 'u22' || matrix.os == 'u24'))
+              && 'linux/amd64,linux/arm/v7,linux/ppc64le'
+              || ''
+            }}${{
+              (matrix.arch == 'amd64' && (matrix.os == 'ol8' || matrix.os == 'el9' || matrix.os == 'el10' || matrix.os == 'u26'))
+              && 'linux/amd64'
               || '' 
             }}
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,11 +33,9 @@ jobs:
           # Intel Runner: Compiles native x86 AND safely triggers emulated tasks for supported OS versions
           - arch: amd64
             runner: ubuntu-latest
-            # The trick: Conditionally append arm/v7 and ppc64le ONLY if it's Ubuntu ('u')
-            platforms: >-
-              linux/amd64
+            platforms: linux/amd64
           - arch: arm64
-            runner: ubuntu-24.04-arm64
+            runner: ubuntu-24.04-arm
             platforms: linux/arm64
 
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
u26 build was crashing because the resulting image was too big to be built inside the 32bit armv7 emulation. This PR moves arm builds to dedicated runners, bypassing the issue and allowing all builds to run successfully, and significantly more quickly.