### PR TITLE
Add live image tagging.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   build:
-    github.ref == 'refs/heads/live'
+    if: github.ref == 'refs/heads/live'
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,3 +1,4 @@
+---
 name: Unbuild Docker Environments
 
 # This action builds Docker images of unibuild for
@@ -6,14 +7,17 @@ name: Unbuild Docker Environments
 
 on:
   push:
-    branches: [ '*' ]
+    branches:
+      - 'main'
+      - '*-test'
+      - 'live'
     # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
+    tags:
+      -  'v*.*.*'
   pull_request:
-    branches: [ 'main' ]
+    branches:
+      - 'main'
   workflow_dispatch:
-    branches: [ '*' ]
-    tags: [ 'v*.*.*' ]
 
 env:
   REGISTRY: ghcr.io
@@ -24,6 +28,7 @@ env:
 
 jobs:
   build:
+    if: github.ref != 'refs/heads/live'
     strategy:
       fail-fast: true
       matrix:
@@ -63,7 +68,7 @@ jobs:
           buildkitd-config-inline: |
             [worker.containerd]
               prefer32 = true
- 
+
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
@@ -89,6 +94,7 @@ jobs:
             type=ref,event=tag
             type=ref,event=pr
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=sha,format=long,prefix=
 
       #
       # Platform Builds
@@ -108,9 +114,39 @@ jobs:
             }}${{
               (matrix.arch == 'amd64' && (matrix.os == 'ol8' || matrix.os == 'el9' || matrix.os == 'el10' || matrix.os == 'u26'))
               && 'linux/amd64'
-              || '' 
+              || ''
             }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+  # -------------------------------------------------------------------
+  # NEW JOB: Fires ONLY on a push to live (like your fast-forward merge)
+  # -------------------------------------------------------------------
+  promote-to-live:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/live'
+    permissions:
+      packages: write
+    strategy:
+      matrix:
+        os: [ 'ol8', 'el9', 'el10', 'u20', 'u22', 'u24', 'u26' ]
+    steps:
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Reg-client is a super fast utility to tag images directly inside the registry
+      # without downloading/pulling the actual image layers.
+      - name: Set up regctl
+        uses: regclient/actions/regctl-installer@main
+
+      - name: Promote SHA image to Live tag
+        run: |
+          IMAGE_PATH="${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/${{ matrix.os }}"
+
+          # Copy the existing SHA tag (built previously on main) to the live tag inside GHCR
+          regctl image copy "${IMAGE_PATH}:${{ github.sha }}" "${IMAGE_PATH}:live"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   build:
-    if: github.ref == 'refs/heads/live'
+    if: github.ref != 'refs/heads/live'
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   build:
-    if: github.ref != 'refs/heads/live'
+    github.ref == 'refs/heads/live'
     strategy:
       fail-fast: true
       matrix:
@@ -125,7 +125,7 @@ jobs:
   # -------------------------------------------------------------------
   promote-to-live:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/live'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/live'
     permissions:
       packages: write
     strategy:

--- a/README.md
+++ b/README.md
@@ -455,3 +455,7 @@ unibuild build
 ```
 
 Simply replace the project (pscheduler) with whatever perfSONAR repository you are trying to build and the target OS (el9) with the target OS to build packages.
+
+## Live image tagging
+
+To avoid the necessity of keeping individual Dockerfiles/docker-compose files current with the latest build, the `live` branch can be pointed at any commit with a successful build and it will be copied to `ghcr.io.perfsonar/unibuild/<platform>:live`, which should be used in any repo that needs a current unibuild image.

--- a/docker-envs/docker-compose.yml
+++ b/docker-envs/docker-compose.yml
@@ -1,3 +1,4 @@
+---
 version: '3.9'
 
 ###
@@ -83,65 +84,65 @@ services:
     volumes: *default-volumes
   u20_amd64:
     platform: "linux/amd64"
-    image: ghcr.io/perfsonar/unibuild/u20:latest@sha256:cb587c42b7d12575c8510c1d09beaa0d52c14523316737f7714b90a7870e000e
+    image: ghcr.io/perfsonar/unibuild/u20:live
     volumes: *default-volumes
   u20_arm64:
     platform: "linux/arm64/v8"
-    image: ghcr.io/perfsonar/unibuild/u20:latest@sha256:fb7ae46f697b2201d613077f017435f075fb2309e833cb20c65a862131899283
+    image: ghcr.io/perfsonar/unibuild/u20:live
     volumes: *default-volumes
   u20_armv7:
     platform: "linux/arm/v7"
-    image: ghcr.io/perfsonar/unibuild/u20:latest@sha256:21ca5a06cd71a946ff3c5e0965c4164fa45e8bb0831a0d21c72b568aeffa77ff
+    image: ghcr.io/perfsonar/unibuild/u20:live
     volumes: *default-volumes
   u20_ppc64le:
     platform: "linux/ppc64le"
-    image: ghcr.io/perfsonar/unibuild/u20:latest@sha256:8ea06ccff6bd61549531385060cc20b82ac02866f859261cbf74e88de0a1d198
+    image: ghcr.io/perfsonar/unibuild/u20:live
     volumes: *default-volumes
   u22_amd64:
     platform: "linux/amd64"
-    image: ghcr.io/perfsonar/unibuild/u22:latest@sha256:1d9d0cfcef556aa986a771afc2be34989250859a09ecfdbabd3c25bbc8def34e
+    image: ghcr.io/perfsonar/unibuild/u22:live
     volumes: *default-volumes
   u22_arm64:
     platform: "linux/arm64/v8"
-    image: ghcr.io/perfsonar/unibuild/u22:latest@sha256:8e0ea73269ed7748246caae5b6ec2bf04599070164935c5566497cb5a0ba3cb4
+    image: ghcr.io/perfsonar/unibuild/u22:live
     volumes: *default-volumes
   u22_armv7:
     platform: "linux/arm/v7"
-    image: ghcr.io/perfsonar/unibuild/u22:latest@sha256:561f7d1fa5f633bb856502af26dfad972079841e48750c6caaf4448a3deb56fa
+    image: ghcr.io/perfsonar/unibuild/u22:live
     volumes: *default-volumes
   u22_ppc64le:
     platform: "linux/ppc64le"
-    image: ghcr.io/perfsonar/unibuild/u22:latest@sha256:07d866df2906cc2a18d64d8b5b68ac182e10804034ef7ac540145c023da15092
+    image: ghcr.io/perfsonar/unibuild/u22:live
     volumes: *default-volumes
   u24_amd64:
     platform: "linux/amd64"
-    image: ghcr.io/perfsonar/unibuild/u24:latest@sha256:98d77e7dec8c6a96065592ac24fea2d4dcf8852910034fbccaa4fcc1dbb5dc10
+    image: ghcr.io/perfsonar/unibuild/u24:live
     volumes: *default-volumes
   u24_arm64:
     platform: "linux/arm64/v8"
-    image: ghcr.io/perfsonar/unibuild/u24:latest@sha256:002b744fbee0c3fdf646364e7e7f05e86b96969ee8b4d8841b571a528596b351
+    image: ghcr.io/perfsonar/unibuild/u24:live
     volumes: *default-volumes
   u24_armv7:
     platform: "linux/arm/v7"
-    image: ghcr.io/perfsonar/unibuild/u24:latest@sha256:98a9787c78bfcc57105cfe74544a9c9e109e2194e83b4e68baca253598ca61b0
+    image: ghcr.io/perfsonar/unibuild/u24:live
     volumes: *default-volumes
   u24_ppc64le:
     platform: "linux/ppc64le"
-    image: ghcr.io/perfsonar/unibuild/u24:latest@sha256:fd95fd2006814a9ab6fd7d8e677b2c25243068441b9b943bdc470298598f4316
+    image: ghcr.io/perfsonar/unibuild/u24:live
     volumes: *default-volumes
   u26_amd64:
     platform: "linux/amd64"
-    image: ghcr.io/perfsonar/unibuild/u26:latest@sha256:98d77e7dec8c6a96065592ac24fea2d4dcf8852910034fbccaa4fcc1dbb5dc10
+    image: ghcr.io/perfsonar/unibuild/u26:live
     volumes: *default-volumes
   u26_arm64:
     platform: "linux/arm64/v8"
-    image: ghcr.io/perfsonar/unibuild/u26:latest@sha256:002b744fbee0c3fdf646364e7e7f05e86b96969ee8b4d8841b571a528596b351
+    image: ghcr.io/perfsonar/unibuild/u26:live
     volumes: *default-volumes
   u26_armv7:
     platform: "linux/arm/v7"
-    image: ghcr.io/perfsonar/unibuild/u26:latest@sha256:98a9787c78bfcc57105cfe74544a9c9e109e2194e83b4e68baca253598ca61b0
+    image: ghcr.io/perfsonar/unibuild/u26:live
     volumes: *default-volumes
   u26_ppc64le:
     platform: "linux/ppc64le"
-    image: ghcr.io/perfsonar/unibuild/u26:latest@sha256:fd95fd2006814a9ab6fd7d8e677b2c25243068441b9b943bdc470298598f4316
+    image: ghcr.io/perfsonar/unibuild/u26:live
     volumes: *default-volumes


### PR DESCRIPTION
Previously, the image sha would need to be updated every time another unibuild image is created. This action
- restricts build actions to `main` and branches like `*-test` for one-off build testing.
- the `live` branch pointer can be placed at any commit with a working build, which will copy this image to the `live` registry tag.
- Commensurate change made in docker-compose.yml